### PR TITLE
Minimize overflowing mobile nav and footer

### DIFF
--- a/anfahrt.html
+++ b/anfahrt.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="assets/images/favicon.ico">
     <link rel="apple-touch-icon" href="assets/images/logo-transparent-small.png">
     <link rel="stylesheet" href="assets/css/styles.css">
+    <script defer src="assets/js/app.js"></script>
   </head>
   <body>
     <header class="site-header">
@@ -15,7 +16,8 @@
           <img src="assets/images/logo-transparent-small.png" alt="Logo" width="40" height="40">
           <span>Schwimmbad Hettenleidelheim</span>
         </a>
-        <nav class="nav-links">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">Menü</button>
+        <nav id="site-nav" class="nav-links">
           <a href="bad.html">Das Bad</a>
           <a href="oeffnungszeiten.html">Öffnungszeiten</a>
           <a href="eintrittspreise.html">Eintrittspreise</a>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -85,6 +85,27 @@ p { margin: 0 0 1rem; }
   background: var(--bg-alt);
 }
 
+/* Mobile navigation */
+.nav-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: .5rem .75rem;
+  border: 1px solid var(--border);
+  border-radius: .5rem;
+  background: var(--bg);
+  color: var(--text);
+}
+.site-header .nav-links {
+  display: none;
+  flex-direction: column;
+  width: 100%;
+  border-top: 1px solid var(--border);
+  padding-top: .25rem;
+}
+.site-header .nav-links.open { display: flex; }
+.site-header .nav-links a { padding: .6rem .75rem; }
+
 /* Hero */
 .hero {
   background: linear-gradient(0deg, #ffffff, #ffffff), url("../images/index-70.jpg") center/cover no-repeat;
@@ -132,6 +153,8 @@ section .container > *:last-child { margin-bottom: 0; }
 }
 .site-footer a { color: #eaf6ff; }
 .footer-inner { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 1rem 0; flex-wrap: wrap; }
+/* Footer: stack on small screens to avoid overflow */
+.footer-inner { flex-direction: column; align-items: center; text-align: center; gap: .5rem; }
 
 /* Tables */
 table { width: 100%; border-collapse: collapse; }
@@ -166,5 +189,8 @@ tbody tr:hover { background: #fafafa; }
 
 @media (min-width: 720px) {
   .hero-inner { grid-template-columns: 1.2fr .8fr; }
+  .nav-toggle { display: none; }
+  .site-header .nav-links { display: flex; flex-direction: row; width: auto; border-top: 0; padding-top: 0; }
+  .footer-inner { flex-direction: row; align-items: center; text-align: left; }
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,17 @@
+// Minimal JS to toggle mobile navigation visibility
+(function () {
+  var toggleButtons = document.querySelectorAll('.nav-toggle');
+  if (!toggleButtons || toggleButtons.length === 0) return;
+
+  toggleButtons.forEach(function (button) {
+    button.addEventListener('click', function () {
+      var navId = button.getAttribute('aria-controls');
+      var nav = document.getElementById(navId);
+      if (!nav) return;
+      var expanded = button.getAttribute('aria-expanded') === 'true';
+      button.setAttribute('aria-expanded', String(!expanded));
+      nav.classList.toggle('open', !expanded);
+    });
+  });
+})();
+

--- a/bad.html
+++ b/bad.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="assets/images/favicon.ico">
     <link rel="apple-touch-icon" href="assets/images/logo-transparent-small.png">
     <link rel="stylesheet" href="assets/css/styles.css">
+    <script defer src="assets/js/app.js"></script>
     <script defer src="assets/js/lightbox.js"></script>
   </head>
   <body>
@@ -16,7 +17,8 @@
           <img src="assets/images/logo-transparent-small.png" alt="Logo" width="40" height="40">
           <span>Schwimmbad Hettenleidelheim</span>
         </a>
-        <nav class="nav-links">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">Menü</button>
+        <nav id="site-nav" class="nav-links">
           <a aria-current="page" href="bad.html">Das Bad</a>
           <a href="oeffnungszeiten.html">Öffnungszeiten</a>
           <a href="eintrittspreise.html">Eintrittspreise</a>

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="assets/images/favicon.ico">
     <link rel="apple-touch-icon" href="assets/images/logo-transparent-small.png">
     <link rel="stylesheet" href="assets/css/styles.css">
+    <script defer src="assets/js/app.js"></script>
   </head>
   <body>
     <header class="site-header">
@@ -15,7 +16,8 @@
           <img src="assets/images/logo-transparent-small.png" alt="Logo" width="40" height="40">
           <span>Schwimmbad Hettenleidelheim</span>
         </a>
-        <nav class="nav-links">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">Menü</button>
+        <nav id="site-nav" class="nav-links">
           <a href="bad.html">Das Bad</a>
           <a href="oeffnungszeiten.html">Öffnungszeiten</a>
           <a href="eintrittspreise.html">Eintrittspreise</a>

--- a/eintrittspreise.html
+++ b/eintrittspreise.html
@@ -8,6 +8,7 @@
     <link rel="icon" href="assets/images/favicon.ico">
     <link rel="apple-touch-icon" href="assets/images/logo-transparent-small.png">
     <link rel="stylesheet" href="assets/css/styles.css">
+    <script defer src="assets/js/app.js"></script>
   </head>
   <body>
     <header class="site-header">
@@ -16,7 +17,8 @@
           <img src="assets/images/logo-transparent-small.png" alt="Logo" width="40" height="40">
           <span>Schwimmbad Hettenleidelheim</span>
         </a>
-        <nav class="nav-links">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">Menü</button>
+        <nav id="site-nav" class="nav-links">
           <a href="bad.html">Das Bad</a>
           <a href="oeffnungszeiten.html">Öffnungszeiten</a>
           <a aria-current="page" href="eintrittspreise.html">Eintrittspreise</a>

--- a/foerderverein.html
+++ b/foerderverein.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="assets/images/favicon.ico">
     <link rel="apple-touch-icon" href="assets/images/logo-transparent-small.png">
     <link rel="stylesheet" href="assets/css/styles.css">
+    <script defer src="assets/js/app.js"></script>
   </head>
   <body>
     <header class="site-header">
@@ -15,7 +16,8 @@
           <img src="assets/images/logo-transparent-small.png" alt="Logo" width="40" height="40">
           <span>Schwimmbad Hettenleidelheim</span>
         </a>
-        <nav class="nav-links">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">Menü</button>
+        <nav id="site-nav" class="nav-links">
           <a href="bad.html">Das Bad</a>
           <a href="oeffnungszeiten.html">Öffnungszeiten</a>
           <a href="eintrittspreise.html">Eintrittspreise</a>

--- a/impressum.html
+++ b/impressum.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="assets/images/favicon.ico">
     <link rel="apple-touch-icon" href="assets/images/logo-transparent-small.png">
     <link rel="stylesheet" href="assets/css/styles.css">
+    <script defer src="assets/js/app.js"></script>
   </head>
   <body>
     <header class="site-header">
@@ -15,7 +16,8 @@
           <img src="assets/images/logo-transparent-small.png" alt="Logo" width="40" height="40">
           <span>Schwimmbad Hettenleidelheim</span>
         </a>
-        <nav class="nav-links">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">Menü</button>
+        <nav id="site-nav" class="nav-links">
           <a href="bad.html">Das Bad</a>
           <a href="oeffnungszeiten.html">Öffnungszeiten</a>
           <a href="eintrittspreise.html">Eintrittspreise</a>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <link rel="icon" href="assets/images/favicon.ico">
     <link rel="apple-touch-icon" href="assets/images/logo-transparent-small.png">
     <link rel="stylesheet" href="assets/css/styles.css">
+    <script defer src="assets/js/app.js"></script>
   </head>
   <body>
     <header class="site-header">
@@ -21,7 +22,8 @@
           <img src="assets/images/logo-transparent-small.png" alt="Logo Schwimmbad Hettenleidelheim" width="40" height="40">
           <span>Schwimmbad Hettenleidelheim</span>
         </a>
-        <nav class="nav-links">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">Menü</button>
+        <nav id="site-nav" class="nav-links">
           <a href="bad.html">Das Bad</a>
           <a href="oeffnungszeiten.html">Öffnungszeiten</a>
           <a href="eintrittspreise.html">Eintrittspreise</a>

--- a/oeffnungszeiten.html
+++ b/oeffnungszeiten.html
@@ -7,6 +7,7 @@
     <link rel="icon" href="assets/images/favicon.ico">
     <link rel="apple-touch-icon" href="assets/images/logo-transparent-small.png">
     <link rel="stylesheet" href="assets/css/styles.css">
+    <script defer src="assets/js/app.js"></script>
   </head>
   <body>
     <header class="site-header">
@@ -15,7 +16,8 @@
           <img src="assets/images/logo-transparent-small.png" alt="Logo" width="40" height="40">
           <span>Schwimmbad Hettenleidelheim</span>
         </a>
-        <nav class="nav-links">
+        <button class="nav-toggle" aria-expanded="false" aria-controls="site-nav">Menü</button>
+        <nav id="site-nav" class="nav-links">
           <a href="bad.html">Das Bad</a>
           <a aria-current="page" href="oeffnungszeiten.html">Öffnungszeiten</a>
           <a href="eintrittspreise.html">Eintrittspreise</a>


### PR DESCRIPTION
Add a mobile navigation menu and make the footer stack to prevent overflow on small screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-d05efa88-b55e-4266-964e-a098fa3d805a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d05efa88-b55e-4266-964e-a098fa3d805a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

