### PR TITLE
Fix broken image link

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,13 +3,13 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   output: 'export',
   // Ensure deployment works under subpath like /Schwimmbad-hettenleidelheim
-  basePath: '/Schwimmbad-hettenleidelheim',
-  assetPrefix: '/Schwimmbad-hettenleidelheim/',
+  basePath: '/schwimmbad-hettenleidelheim',
+  assetPrefix: '/schwimmbad-hettenleidelheim/',
   images: {
     unoptimized: true,
   },
   env: {
-    NEXT_PUBLIC_BASE_PATH: '/Schwimmbad-hettenleidelheim',
+    NEXT_PUBLIC_BASE_PATH: '/schwimmbad-hettenleidelheim',
   },
 }
 

--- a/src/app/datenschutz/page.tsx
+++ b/src/app/datenschutz/page.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 export const metadata = { title: 'Datenschutz – Freibad Hettenleidelheim' }
 
 export default function PrivacyPage() {
+	const prefix = process.env.NEXT_PUBLIC_BASE_PATH || ''
 	return (
 		<div className='space-y-8'>
 			<h1 className='text-3xl font-bold'>Datenschutz</h1>
@@ -42,13 +43,13 @@ export default function PrivacyPage() {
 			</div>
 			<div className='grid gap-4 sm:grid-cols-3'>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/plane_geschlossen.JPG'} alt='Abdeckung geschlossen' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/plane_geschlossen.JPG`} alt='Abdeckung geschlossen' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/tischtennisplatte.JPG'} alt='Tischtennisplatte' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/tischtennisplatte.JPG`} alt='Tischtennisplatte' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/bodentrampolin.JPG'} alt='Bodentrampolin' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/bodentrampolin.JPG`} alt='Bodentrampolin' fill className='object-cover' />
 				</div>
 			</div>
 		</div>

--- a/src/app/galerie/page.tsx
+++ b/src/app/galerie/page.tsx
@@ -38,7 +38,7 @@ export default function GaleriePage() {
 						<li key={file} className='group overflow-hidden rounded-lg ring-1 ring-slate-200 bg-white'>
 							<a href={`${prefix}/gallery/${file}`} target='_blank' rel='noopener noreferrer'>
 								<div className='relative aspect-[4/3]'>
-									<Image src={`/gallery/${file}`} alt={file} fill sizes='(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw' className='object-cover transition-transform duration-300 group-hover:scale-105' />
+									<Image src={`${prefix}/gallery/${file}`} alt={file} fill sizes='(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw' className='object-cover transition-transform duration-300 group-hover:scale-105' />
 								</div>
 							</a>
 						</li>

--- a/src/app/historie/page.tsx
+++ b/src/app/historie/page.tsx
@@ -37,7 +37,7 @@ export default function HistoriePage() {
             <li key={file} className='group overflow-hidden rounded-lg ring-1 ring-slate-200 bg-white'>
               <a href={`${prefix}/gallery/${file}`} target='_blank' rel='noopener noreferrer'>
                 <div className='relative aspect-[4/3]'>
-                  <Image src={`/gallery/${file}`} alt={file} fill sizes='(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw' className='object-cover transition-transform duration-300 group-hover:scale-105' />
+                  <Image src={`${prefix}/gallery/${file}`} alt={file} fill sizes='(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw' className='object-cover transition-transform duration-300 group-hover:scale-105' />
                 </div>
               </a>
               <div className='p-3 text-sm text-slate-600'>{file.replace(/\.[^.]+$/, '')}</div>

--- a/src/app/impressum/page.tsx
+++ b/src/app/impressum/page.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 export const metadata = { title: 'Impressum – Freibad Hettenleidelheim' }
 
 export default function ImpressumPage() {
+	const prefix = process.env.NEXT_PUBLIC_BASE_PATH || ''
 	return (
 		<div className='space-y-8'>
 			<h1 className='text-3xl font-bold'>Impressum</h1>
@@ -38,13 +39,13 @@ export default function ImpressumPage() {
 			</div>
 			<div className='grid gap-4 sm:grid-cols-3'>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/headermitlogo-60.jpg'} alt='Logo im Header' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/headermitlogo-60.jpg`} alt='Logo im Header' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/index-70.jpg'} alt='Bad Übersicht' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/index-70.jpg`} alt='Bad Übersicht' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/SWRFernsehen.JPG'} alt='SWR Fernsehen' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/SWRFernsehen.JPG`} alt='SWR Fernsehen' fill className='object-cover' />
 				</div>
 			</div>
 		</div>

--- a/src/app/kontakt/page.tsx
+++ b/src/app/kontakt/page.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 export const metadata = { title: 'Anfahrt & Kontakt – Freibad Hettenleidelheim' }
 
 export default function ContactPage() {
+	const prefix = process.env.NEXT_PUBLIC_BASE_PATH || ''
 	return (
 		<div className='space-y-8'>
 			<h1 className='text-3xl font-bold'>Anfahrt & Kontakt</h1>
@@ -30,13 +31,13 @@ export default function ContactPage() {
 			</div>
 			<div className='grid gap-4 sm:grid-cols-3'>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/fahrradstaender.JPG'} alt='Fahrradständer' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/fahrradstaender.JPG`} alt='Fahrradständer' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/Ladestation.JPG'} alt='Ladestation' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/Ladestation.JPG`} alt='Ladestation' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/begegnungsplatz.JPG'} alt='Begegnungsplatz' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/begegnungsplatz.JPG`} alt='Begegnungsplatz' fill className='object-cover' />
 				</div>
 			</div>
 		</div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 	title: 'Freibad Hettenleidelheim',
 	description:
 		'Freibad Hettenleidelheim – Öffnungszeiten, Preise, Anfahrt, Förderverein und mehr.',
-	metadataBase: new URL('https://www.schwimmbad-hettenleidelheim.de/Schwimmbad-hettenleidelheim'),
+	metadataBase: new URL('https://loggel.github.io/schwimmbad-hettenleidelheim'),
 	openGraph: {
 		title: 'Freibad Hettenleidelheim',
 		description:

--- a/src/app/oeffnungszeiten/page.tsx
+++ b/src/app/oeffnungszeiten/page.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 export const metadata = { title: 'Öffnungszeiten – Freibad Hettenleidelheim' }
 
 export default function HoursPage() {
+	const prefix = process.env.NEXT_PUBLIC_BASE_PATH || ''
 	return (
 		<div className='space-y-8'>
 			<h1 className='text-3xl font-bold'>Öffnungszeiten</h1>
@@ -23,13 +24,13 @@ export default function HoursPage() {
 			</div>
 			<div className='grid gap-4 sm:grid-cols-3'>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/nichtschwimmer.jpg'} alt='Nichtschwimmerbereich' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/nichtschwimmer.jpg`} alt='Nichtschwimmerbereich' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/umrandung.JPG'} alt='Anlagen im Bad' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/umrandung.JPG`} alt='Anlagen im Bad' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/schwimmbad_2023.jpg'} alt='Freibad 2023' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/schwimmbad_2023.jpg`} alt='Freibad 2023' fill className='object-cover' />
 				</div>
 			</div>
 		</div>

--- a/src/app/preise/page.tsx
+++ b/src/app/preise/page.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 export const metadata = { title: 'Eintrittspreise – Freibad Hettenleidelheim' }
 
 export default function PricesPage() {
+	const prefix = process.env.NEXT_PUBLIC_BASE_PATH || ''
 	return (
 		<div className='space-y-8'>
 			<h1 className='text-3xl font-bold'>Eintrittspreise</h1>
@@ -33,13 +34,13 @@ export default function PricesPage() {
 			</div>
 			<div className='grid gap-4 sm:grid-cols-3'>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/wertschliessfaecher_innen.JPG'} alt='Wertschließfächer innen' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/wertschliessfaecher_innen.JPG`} alt='Wertschließfächer innen' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/Umkleiden.JPG'} alt='Umkleiden' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/Umkleiden.JPG`} alt='Umkleiden' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={'/gallery/ibench.JPG'} alt='Sitzbank im Bad' fill className='object-cover' />
+					<Image src={`${prefix}/gallery/ibench.JPG`} alt='Sitzbank im Bad' fill className='object-cover' />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Fix 404 errors for images by correcting Next.js base path and image source prefixes for GitHub Pages deployment.

Images were not loading on GitHub Pages because their URLs were missing the repository subpath (`/schwimmbad-hettenleidelheim`). Additionally, the `basePath` in `next.config.ts` used an incorrect capitalization, which GitHub Pages treats as case-sensitive. This PR updates the Next.js configuration and prefixes all image `src` attributes to resolve correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-cdb9bad1-0e72-49f6-a4ca-e885b038b83f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cdb9bad1-0e72-49f6-a4ca-e885b038b83f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

