### PR TITLE
Fix app-breaking prefixes

### DIFF
--- a/src/app/datenschutz/page.tsx
+++ b/src/app/datenschutz/page.tsx
@@ -42,13 +42,13 @@ export default function PrivacyPage() {
 			</div>
 			<div className='grid gap-4 sm:grid-cols-3'>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={`${prefix}/gallery/plane_geschlossen.JPG`} alt='Abdeckung geschlossen' fill className='object-cover' />
+					<Image src={'/gallery/plane_geschlossen.JPG'} alt='Abdeckung geschlossen' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={`${prefix}/gallery/tischtennisplatte.JPG`} alt='Tischtennisplatte' fill className='object-cover' />
+					<Image src={'/gallery/tischtennisplatte.JPG'} alt='Tischtennisplatte' fill className='object-cover' />
 				</div>
 				<div className='relative aspect-[4/3] w-full overflow-hidden rounded-lg ring-1 ring-slate-200'>
-					<Image src={`${prefix}/gallery/bodentrampolin.JPG`} alt='Bodentrampolin' fill className='object-cover' />
+					<Image src={'/gallery/bodentrampolin.JPG'} alt='Bodentrampolin' fill className='object-cover' />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Fix broken image paths in `datenschutz/page.tsx` by removing the undefined `prefix`.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd2d3afb-5fb6-4be0-907c-ed2e44109b5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd2d3afb-5fb6-4be0-907c-ed2e44109b5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

